### PR TITLE
fix: harden backend build safeguards

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .*
 *.sqlite
+*.sql
+logs
 media
 static
 venv

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ test:
 	docker exec -it saleor-web-1 bash -c 'IS_TESTING=True REMOTE=False DJANGO_SETTINGS_MODULE=saleor.settings pytest src/saleor-oye/saleor_oye'
 
 schema:
-docker exec -it saleor-web-1 bash -c "./manage.py graphql_schema --out=-" > ../nuxt-oye-records/graphql.schema.json
+	docker exec -it saleor-web-1 bash -c "./manage.py graphql_schema --out=-" > ../nuxt-oye-records/graphql.schema.json


### PR DESCRIPTION
## What changed

- exclude SQL dumps and runtime logs from Docker build contexts
- fix the malformed `schema` Make target so the Makefile parses again

## Why

The production update helper was accidentally run from the storefront checkout and replaced the backend image. During recovery, a direct backend build also attempted to send more than 10 GB because runtime logs and database dumps were not excluded. The malformed Make target additionally prevented `make build` from running.

## Impact

Backend builds no longer include large local database/log artifacts, and the existing Make targets are usable again.

## Validation

- `git diff --check`
- `make -n build schema`
- production recovery used a clean 9.2 MB Git-archive build context
