### PR TITLE
fix: update vulnerable backend dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ django-prices==2.3.0
 django-redis==5.3.0
 django-storages==1.5.2
 django-versatileimagefield==3.0
-django==4.2.5
-djangorestframework==3.14.0
+django==4.2.30
+djangorestframework==3.15.2
 faker==0.7.7
 google-i18n-address==2.0.1
 graphene-django==3.1.5
@@ -29,7 +29,7 @@ jsonfield==3.1.0
 mock==2.0.0
 purl==1.3
 pytest==7.4.2
-requests==2.31.0
+requests==2.33.0
 satchless==1.2.0
 text-unidecode==1.0
 Pillow==9.5.0
@@ -79,7 +79,7 @@ elasticsearch-dsl==8.9.0
 django-ajax-selects==2.2.0
 
 django-rest-auth==0.9.1
-djangorestframework-simplejwt==5.3.0
+djangorestframework-simplejwt==5.5.1
 
 
 attrdict==2.0.1
@@ -101,7 +101,7 @@ python-logstash==0.4.8
 
 mailchimp3==3.0.2
 
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 dacite==1.8.1
 
 
@@ -114,4 +114,3 @@ pytest-django==4.5.2
 factory-boy==2.11.1
 
 djangorestframework-csv==2.1.1
-


### PR DESCRIPTION
## Summary

- update Django from 4.2.5 to the final 4.2.30 patch release
- update Django REST Framework to 3.15.2
- update Requests to 2.33.0
- update Simple JWT to 5.5.1
- update python-dotenv to 1.2.2

## Why

The pinned backend requirements contained 63 known direct-package vulnerabilities. These focused updates remove the findings that can be addressed without a major framework or rendering-library migration.

## Impact

The backend stays on the Django 4.2 line and receives the available patch-level security fixes. Seventeen findings remain in pytest, Pillow, and WeasyPrint; resolving those requires separately reviewed major upgrades.

## Validation

- direct pinned-requirement audit with `pip-audit --no-deps --disable-pip`
- findings reduced from 63 across 8 packages to 17 across 3 packages

A full runtime test was not available locally because this application requires the private `saleor_oye` package, Python 3.10, MySQL native libraries, and the host service environment.
