### PR TITLE
ci: require production backend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches:
+      - master
+      - gfeat/upgrades
+  push:
+    branches:
+      - master
+      - gfeat/upgrades
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  production-build:
+    name: Production Docker build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build production image
+        env:
+          SALEOR_OYE_DEPLOY_KEY: ${{ secrets.SALEOR_OYE_DEPLOY_KEY }}
+        run: |
+          test -n "$SALEOR_OYE_DEPLOY_KEY"
+          install -m 600 /dev/null /tmp/saleor_oye_deploy_key
+          printf '%s\n' "$SALEOR_OYE_DEPLOY_KEY" > /tmp/saleor_oye_deploy_key
+          eval "$(ssh-agent -s)"
+          ssh-add /tmp/saleor_oye_deploy_key
+          rm /tmp/saleor_oye_deploy_key
+          DOCKER_BUILDKIT=1 docker build --pull --ssh "default=$SSH_AUTH_SOCK" --tag oye-saleor:ci .
+
+      - name: Verify application imports
+        run: |
+          docker run --rm --entrypoint python oye-saleor:ci -c "import saleor; import saleor_oye"


### PR DESCRIPTION
## Summary

- add a GitHub Actions check that builds the production Saleor Dockerfile
- authenticate the private `saleor-oye-records` dependency with a dedicated read-only deploy key
- verify that both `saleor` and `saleor_oye` import from the resulting image

## Why

Backend dependency, framework, and container changes need to be tested against the exact Docker build and paired private extension before merge.

## Impact

No application code, requirements, deployment, or runtime configuration changes are included. The deploy key has read-only access to the extension repository and cannot push or deploy.

## Validation

- workflow YAML parsed locally
- read-only deploy key created for `saleor-oye-records`
- `SALEOR_OYE_DEPLOY_KEY` stored as an Actions secret in `saleor`

This PR remains a draft until its production Docker build passes in GitHub Actions.
